### PR TITLE
Add pcscd service for driver

### DIFF
--- a/roles/driver/tasks/main.yml
+++ b/roles/driver/tasks/main.yml
@@ -20,6 +20,20 @@
     env PATH=$PATH:{{ nvm_dir }}/versions/node/{{ node_version }}/bin {{ nvm_dir }}/versions/node/{{ node_version }}/lib/node_modules/pm2/bin/pm2 unstartup systemd -u {{ user }} --hp /home/{{ user }}
   ignore_errors: yes
 
+- name: Install pcscd
+  become: true
+  apt:
+    name: pcscd
+
+- name: Enable and start pcscd service
+  become: true
+  systemd:
+    name: pcscd
+    state: restarted
+    enabled: true
+  # May fail during preseed
+  ignore_errors: true
+
 - name: Remove driver directory
   become: true
   file:


### PR DESCRIPTION
This is a prerequisite for the driver supporting RFID on Linux.

If `pcscd` is not available, the driver will still try to connect but fail. It performs exponential backoff in this case<sup>[1]</sup>. 

[1]: https://github.com/dividat/driver/blob/783ebbc/src/dividat-driver/rfid/pcsc.go#L26-L46