### PR TITLE
Update for 18.04 LTS

### DIFF
--- a/installer/ubuntu/boot.ipxe
+++ b/installer/ubuntu/boot.ipxe
@@ -1,7 +1,7 @@
 #!ipxe
 
 
-set ubuntu_version artful
+set ubuntu_version bionic
 set arch amd64
 set ubuntu_mirror ch.archive.ubuntu.com
 

--- a/installer/ubuntu/boot.ipxe
+++ b/installer/ubuntu/boot.ipxe
@@ -5,10 +5,10 @@ set ubuntu_version artful
 set arch amd64
 set ubuntu_mirror ch.archive.ubuntu.com
 
-#set kickstart_config http://boot.dividat.com/ubuntu/ks.cfg
+#set kickstart_config https://boot.dividat.com/ubuntu/ks.cfg
 #set params ks=${kickstart_config}
 
-set install_params auto=true priority=critical locale=en_US keyboard-configuration/layoutcode=us preseed/url=http://boot.dividat.com/ubuntu/preseed.cfg preseed/interactive=false
+set install_params auto=true priority=critical locale=en_US keyboard-configuration/layoutcode=us preseed/url=https://boot.dividat.com/ubuntu/preseed.cfg preseed/interactive=false
 
 set dir ubuntu/dists/${ubuntu_version}/main/installer-${arch}/current/images/netboot/ubuntu-installer/${arch}
 

--- a/installer/ubuntu/preseed.cfg
+++ b/installer/ubuntu/preseed.cfg
@@ -55,7 +55,7 @@ d-i hw-detect/load_firmware boolean true
 # Mirror
 #################################
 d-i mirror/http/mirror select ch.archive.ubuntu.com
-d-i mirror/suite string artful
+d-i mirror/suite string bionic
 
 
 #################################

--- a/roles/management/tasks/main.yml
+++ b/roles/management/tasks/main.yml
@@ -90,9 +90,22 @@
     url: https://www.zerotier.com/misc/contact@zerotier.com.gpg
 
 - name: Add zerotier apt repository
+  when: ansible_distribution_version == '17.04'
+  become: true
+  apt_repository:
+    repo: deb http://download.zerotier.com/debian/zesty zesty main
+
+- name: Add zerotier apt repository
+  when: ansible_distribution_version == '17.10'
   become: true
   apt_repository:
     repo: deb http://download.zerotier.com/debian/artful artful main
+
+- name: Add zerotier apt repository
+  when: ansible_distribution_version == '18.04'
+  become: true
+  apt_repository:
+    repo: deb http://download.zerotier.com/debian/bionic bionic main
 
 - name: Install zerotier-one
   become: true

--- a/roles/ubuntu_base/tasks/main.yml
+++ b/roles/ubuntu_base/tasks/main.yml
@@ -61,6 +61,12 @@
     path: /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
     state: touch
 
+- name: Disable welcome screen
+  become: true
+  apt:
+    name: gnome-initial-setup
+    state: absent
+
 - name: Disable update manager
   become: true
   apt:


### PR DESCRIPTION
Repos for 17.10 just stopped receiving updates (but should stay available for some more months).

Looks like we can start provisioning 18.04 machines with little added effort.