### PR TITLE
Add flag to set permissive Chrome autoplay policy

### DIFF
--- a/roles/ubuntu_lab/templates/lab-kiosk.sh.j2
+++ b/roles/ubuntu_lab/templates/lab-kiosk.sh.j2
@@ -26,7 +26,7 @@ sed -i 's/"exit_type":"Crashed"/"exit_type":"None"/' ~/.config/chromium/Default/
 # start chromium in kiosk mode...for ever. ever. ever, ever ever?
 while true
 do
-  chromium-browser --disable-infobars --kiosk {{ lab_url }}
+  chromium-browser --disable-infobars --kiosk --autoplay-policy=no-user-gesture-required {{ lab_url }}
 done
 
 # I apologize a trillion times

--- a/roles/ubuntu_play/templates/play-kiosk.sh.j2
+++ b/roles/ubuntu_play/templates/play-kiosk.sh.j2
@@ -15,7 +15,7 @@ sed -i 's/"exit_type":"Crashed"/"exit_type":"None"/' ~/.config/chromium/Default/
 # start chromium in kiosk mode...for ever. ever. ever, ever ever?
 while true
 do
-  chromium-browser --disable-infobars --kiosk {{ play_url }}
+  chromium-browser --disable-infobars --kiosk --autoplay-policy=no-user-gesture-required {{ play_url }}
 done
 
 # I'm sorry miss Jackson. I am for real...


### PR DESCRIPTION
Sets Chromium's [autoplay policy](https://www.blog.google/products/chrome/improving-autoplay-chrome/) to allow playback without prior user gestures in kiosk mode for Play.

Chromium only counts few events (at least click and tap) as user gestures, so the splash animation would be muted and users performing only interactions through custom hardware would never have sound at all. 