### PR TITLE
Reenable updates on 17.04 machines

### DIFF
--- a/roles/management/tasks/main.yml
+++ b/roles/management/tasks/main.yml
@@ -94,6 +94,7 @@
   become: true
   apt_repository:
     repo: deb http://download.zerotier.com/debian/zesty zesty main
+  ignore_errors: true
 
 - name: Add zerotier apt repository
   when: ansible_distribution_version == '17.10'

--- a/roles/ubuntu_base/tasks/main.yml
+++ b/roles/ubuntu_base/tasks/main.yml
@@ -33,6 +33,11 @@
   raw: apt-get install -y aptitude
   become: true
 
+- name: "Update cache"
+  raw: apt-get update
+  become: true
+  ignore_errors: true
+
 - name: Upgrade packages
   become: true
   apt:


### PR DESCRIPTION
Machines running 17.04 may have deprecated repositories configured. While updating their package cache, errors are produced, even if update succeeds for some repositories. The procedure can complete by allowing cache updates to exit with an error code.